### PR TITLE
feat(basic-index): add styles for pokedex view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import Pokedex from './views/pokedex';
 
 function App() {
   return (
-    <h1>Hello World</h1>
+    <Pokedex></Pokedex>
   );
 }
 

--- a/src/components/pokemon.tsx
+++ b/src/components/pokemon.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+const Pokemon = function ({ pokemon }: {pokemon: any}) {
+  return (
+    <div className='flex flex-col w-1/8 m-2'>
+      <img className='bg-zinc-200 rounded-lg' alt={`${pokemon.name}`} src={pokemon?.avatar} />
+      <div className="flex flex-col px-4">
+        <p className="font-semibold text-gray-400">{formatId(pokemon?.id.toString())}</p>
+        <p className="text-xl font-semibold my-2">{pokemon?.name}</p>
+        <div className='flex m-1'>
+          { pokemon?.types.map((type) => (
+              createTag(type)
+            )) }
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function formatId(id: string){
+  const finalId = 'N.º' + id.padStart(3, '0')
+  return finalId
+}
+
+function defineColor(type: string){
+  if (type === 'fire') {
+    return 'bg-red-700'
+  } else if (type === 'water') {
+    return 'bg-cyan-600'
+  } else if (type === 'grass') {
+    return 'bg-lime-600'
+  } else if (type === 'flying') {
+    return 'bg-violet-600'
+  }
+}
+
+function createTag(type: string){
+  return  <p className={`${defineColor(type)} m-1 text-sm text-white rounded text-center w-1/2`}>{capitalizeFirstLetter(type)}</p>
+}
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+export default Pokemon;

--- a/src/views/pokedex.tsx
+++ b/src/views/pokedex.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Pokemon from '../components/pokemon'
+
+const pokemonList = [
+    {id: 11,
+    name: 'juanito',
+    types: ['fire', 'flying'],
+    avatar: 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/007.png'},
+    {id: 2,
+    name: 'manuelito',
+    types: ['water', 'grass'],
+    avatar: 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/012.png'},
+    {id: 35,
+    name: 'adriano',
+    types: ['flying'],
+    avatar: 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/007.png'},
+    {id: 223,
+    name: 'gustabo',
+    types: ['fire'],
+    avatar: 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/012.png'},
+    {id: 16,
+    name: 'ricardo',
+    types: ['fire', 'flying'],
+    avatar: 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/007.png'},
+    {id: 200,
+    name: 'gonzalito',
+    types: ['fire', 'grass'],
+    avatar: 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/012.png'},
+    {id: 35,
+    name: 'adriano',
+    types: ['flying'],
+    avatar: 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/007.png'},
+    {id: 666,
+    name: 'rosa maría',
+    types: ['grass'],
+    avatar: 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/012.png'}]
+
+const Pokedex = function () {
+    return (
+        <div className='flex justify-center bg-gray-300'>
+            <div className='flex flex-wrap border-2 justify-center w-2/3 bg-white h-screen'>
+            {pokemonList.map((pokemon) => (
+                <Pokemon key={pokemon.id} pokemon={pokemon} />
+            ))}
+            </div>
+        </div>
+    );
+  };
+
+  export default Pokedex;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": false,
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
Basic template and styles for the pokedex view

Note: For now, pokemon info is hardcoded into objects but I intend to use a pokemon API 

![image](https://user-images.githubusercontent.com/69604538/159810380-b2e51cb0-42f7-4449-8f5a-779a3cfdef2a.png)
